### PR TITLE
Fix(app): Knowledge base ingestion command 

### DIFF
--- a/COMMANDS_REFERENCE.md
+++ b/COMMANDS_REFERENCE.md
@@ -1,0 +1,331 @@
+# Kleos-Quira CLI Commands Reference
+
+This document provides detailed information on all available CLI commands, their options, and platform-specific usage examples.
+
+## JSON Parameter Handling
+
+When passing complex parameters as JSON strings via options like `--metadata-map`, `--metadata-filter`, or `--agent-params`, ensure they are correctly quoted and escaped for your specific command-line shell.
+
+### Windows Command Prompt (`cmd.exe`)
+- Enclose the entire JSON string in double quotes (`"`)
+- Escape all inner double quotes with a backslash (`\"`)
+- Example: `--metadata-map "{\"key\":\"value\"}"`
+
+### PowerShell, Bash, Zsh
+- Enclose the JSON string in single quotes (`'`)
+- Example: `--metadata-map '{"key":"value"}'`
+
+---
+
+## Setup Commands
+
+### `setup hackernews` - Setup HackerNews Datasource
+
+Creates a HackerNews datasource connection in MindsDB.
+
+**Usage:**
+```bash
+python main.py setup hackernews --name <datasource_name>
+```
+
+**Arguments:**
+- `--name`: Name for the datasource (default: hackernews_db)
+
+**Example:**
+```bash
+python main.py setup hackernews --name my_hackernews_source
+```
+
+---
+
+## Knowledge Base Commands
+
+### `kb create` - Create a new Knowledge Base
+
+Creates a new Knowledge Base with specified embedding and reranking models.
+
+**Usage:**
+```bash
+python main.py kb create <kb_name> --embedding-model <model> --reranking-model <model> [options]
+```
+
+**Required Arguments:**
+- `<kb_name>`: Name of the Knowledge Base to create
+- `--embedding-model`: Embedding model to use (e.g., nomic-embed-text)  
+- `--reranking-model`: Reranking model to use (e.g., llama3)
+
+**Optional Arguments:**
+- `--content-columns`: Comma-separated list of columns to use as content (default: auto-detect based on table)
+- `--metadata-columns`: Comma-separated list of columns to store as metadata (default: auto-detect based on table)
+- `--id-column`: Column to use as unique identifier (default: id)
+
+**Examples:**
+```bash
+# Basic KB creation
+python main.py kb create my_documents_kb --embedding-model nomic-embed-text --reranking-model llama3
+
+# KB with custom content and metadata columns for HackerNews stories
+python main.py kb create hn_stories_kb --embedding-model nomic-embed-text --reranking-model llama3 --content-columns "title,text" --metadata-columns "id,by,score,time" --id-column id
+
+# KB optimized for comments
+python main.py kb create hn_comments_kb --embedding-model nomic-embed-text --reranking-model llama3 --content-columns "text" --metadata-columns "id,by,parent,time" --id-column id
+```
+
+### `kb ingest` - Ingest data into a Knowledge Base
+
+Ingests data from a HackerNews table into an existing Knowledge Base. The command automatically detects sensible defaults for HackerNews tables and can auto-create the datasource if needed.
+
+**Usage:**
+```bash
+python main.py kb ingest <kb_name> --from-hackernews <table> [options]
+```
+
+**Required Arguments:**
+- `<kb_name>`: Name of the existing Knowledge Base
+- `--from-hackernews`: HackerNews table to ingest from (stories, comments, etc.)
+
+**Optional Arguments:**
+- `--limit`: Maximum number of records to ingest (default: 1000)
+- `--content-columns`: Comma-separated list of columns to use as content (auto-detected for HN tables if not specified)
+- `--metadata-map`: JSON mapping of KB metadata columns to source table columns
+
+**Auto-Detection for HackerNews Tables:**
+- **stories**: content = "title,text", metadata = "id,by,score,time,descendants,url"
+- **comments**: content = "text", metadata = "id,by,parent,time"
+- **Other tables**: content = "text", metadata = "id" (fallback)
+
+**Examples:**
+
+**PowerShell/Bash/Zsh:**
+```bash
+# Simple ingestion with auto-detected columns
+python main.py kb ingest my_documents_kb --from-hackernews stories --limit 50
+
+# Custom content columns only
+python main.py kb ingest my_documents_kb --from-hackernews stories --content-columns title --limit 100
+
+# Custom content and metadata mapping
+python main.py kb ingest my_documents_kb --from-hackernews stories --content-columns title --metadata-map '{"story_id":"id", "author":"by", "score":"score"}' --limit 100
+
+# Ingest comments with custom mapping
+python main.py kb ingest comment_kb --from-hackernews comments --metadata-map '{"comment_id":"id", "author":"by", "parent_story":"parent"}' --limit 200
+```
+
+**Windows Command Prompt:**
+```cmd
+REM Simple ingestion with auto-detected columns
+python main.py kb ingest my_documents_kb --from-hackernews stories --limit 50
+
+REM Custom content columns only
+python main.py kb ingest my_documents_kb --from-hackernews stories --content-columns title --limit 100
+
+REM Custom content and metadata mapping
+python main.py kb ingest my_documents_kb --from-hackernews stories --content-columns title --metadata-map "{\"story_id\":\"id\", \"author\":\"by\", \"score\":\"score\"}" --limit 100
+
+REM Ingest comments with custom mapping
+python main.py kb ingest comment_kb --from-hackernews comments --metadata-map "{\"comment_id\":\"id\", \"author\":\"by\", \"parent_story\":\"parent\"}" --limit 200
+```
+
+### `kb query` - Query a Knowledge Base
+
+Queries a Knowledge Base for relevant content using semantic search.
+
+**Usage:**
+```bash
+python main.py kb query <kb_name> "<query_text>" [options]
+```
+
+**Arguments:**
+- `<kb_name>`: Name of the Knowledge Base to query
+- `<query_text>`: Text to search for (enclose in quotes)
+- `--limit`: Maximum number of results to return (default: 10)
+- `--metadata-filter`: JSON filter to apply to metadata (optional)
+
+**Examples:**
+
+**PowerShell/Bash/Zsh:**
+```bash
+# Basic query
+python main.py kb query my_documents_kb "latest trends in AI"
+
+# Query with result limit
+python main.py kb query my_documents_kb "Python programming tips" --limit 5
+
+# Query with metadata filter
+python main.py kb query my_documents_kb "machine learning" --metadata-filter '{"author":"tech_expert", "score":{"$gt":50}}'
+
+# Search specific topics in HackerNews stories
+python main.py kb query hn_stories_kb "startups and funding" --metadata-filter '{"score":{"$gte":100}}'
+```
+
+**Windows Command Prompt:**
+```cmd
+REM Basic query
+python main.py kb query my_documents_kb "latest trends in AI"
+
+REM Query with result limit
+python main.py kb query my_documents_kb "Python programming tips" --limit 5
+
+REM Query with metadata filter
+python main.py kb query my_documents_kb "machine learning" --metadata-filter "{\"author\":\"tech_expert\", \"score\":{\"$gt\":50}}"
+
+REM Search specific topics in HackerNews stories
+python main.py kb query hn_stories_kb "startups and funding" --metadata-filter "{\"score\":{\"$gte\":100}}"
+```
+
+### `kb list-databases` - List available databases
+
+Lists all databases available in the current MindsDB instance.
+
+**Usage:**
+```bash
+python main.py kb list-databases
+```
+
+**Example Output:**
+```
+Available databases:
+- information_schema
+- mindsdb
+- hackernews_db
+- my_custom_datasource
+```
+
+### `kb create-agent` - Create an AI Agent for a Knowledge Base
+
+Creates an AI agent that can answer questions using a specific Knowledge Base as its knowledge source.
+
+**Usage:**
+```bash
+python main.py kb create-agent <agent_name> <kb_name> --model-name <model> [options]
+```
+
+**Arguments:**
+- `<agent_name>`: Name for the new agent
+- `<kb_name>`: Name of the Knowledge Base to use as knowledge source
+- `--model-name`: AI model to use (e.g., gemini-pro, gpt-4, etc.)
+- `--agent-params`: JSON parameters for the agent configuration (optional)
+
+**Common Agent Parameters:**
+- `temperature`: Controls randomness (0.0-1.0)
+- `prompt_template`: Custom prompt template for the agent
+- `max_tokens`: Maximum response length
+- `api_key`: Model-specific API key (if not in environment)
+
+**Examples:**
+
+**PowerShell/Bash/Zsh:**
+```bash
+# Basic agent creation
+python main.py kb create-agent my_kb_agent my_documents_kb --model-name gemini-pro
+
+# Agent with custom temperature and prompt
+python main.py kb create-agent hn_expert hn_stories_kb --model-name gemini-pro --agent-params '{"temperature":0.2, "prompt_template":"You are an expert analyst of HackerNews content. Answer questions based on the provided articles."}'
+
+# Agent with specific API configuration
+python main.py kb create-agent research_assistant research_kb --model-name gpt-4 --agent-params '{"temperature":0.1, "max_tokens":500, "api_key":"your-openai-key"}'
+```
+
+**Windows Command Prompt:**
+```cmd
+REM Basic agent creation
+python main.py kb create-agent my_kb_agent my_documents_kb --model-name gemini-pro
+
+REM Agent with custom temperature and prompt
+python main.py kb create-agent hn_expert hn_stories_kb --model-name gemini-pro --agent-params "{\"temperature\":0.2, \"prompt_template\":\"You are an expert analyst of HackerNews content. Answer questions based on the provided articles.\"}"
+
+REM Agent with specific API configuration
+python main.py kb create-agent research_assistant research_kb --model-name gpt-4 --agent-params "{\"temperature\":0.1, \"max_tokens\":500, \"api_key\":\"your-openai-key\"}"
+```
+
+### `kb query-agent` - Query an AI Agent
+
+Queries an AI agent for answers based on its associated Knowledge Base.
+
+**Usage:**
+```bash
+python main.py kb query-agent <agent_name> "<question>"
+```
+
+**Arguments:**
+- `<agent_name>`: Name of the agent to query
+- `<question>`: Question to ask the agent (enclose in quotes)
+
+**Examples:**
+```bash
+# Basic agent query
+python main.py kb query-agent my_kb_agent "What are the main topics discussed in the articles?"
+
+# Query HackerNews expert agent
+python main.py kb query-agent hn_expert "What are the most popular programming languages mentioned in recent stories?"
+
+# Complex analytical query
+python main.py kb query-agent research_assistant "Summarize the key trends in AI research from the past year and identify emerging themes."
+```
+
+---
+
+## AI Commands
+
+### `ai chat` - Interactive chat with AI models
+
+Start an interactive chat session with various AI models.
+
+**Usage:**
+```bash
+python main.py ai chat --model <model_name> [options]
+```
+
+**Arguments:**
+- `--model`: AI model to use
+- `--temperature`: Sampling temperature (optional)
+- `--max-tokens`: Maximum tokens in response (optional)
+
+---
+
+## Job Commands
+
+### `job create` - Create a job for data processing
+
+Creates a job for processing data with AI models.
+
+**Usage:**
+```bash
+python main.py job create <job_name> --model <model> --input <input_file> [options]
+```
+
+---
+
+## Best Practices
+
+1. **Always test with small limits first**: When ingesting data, start with `--limit 10` to verify the configuration works correctly.
+
+2. **Use descriptive names**: Choose clear, descriptive names for KBs and agents that reflect their purpose.
+
+3. **Verify your datasource**: Use `kb list-databases` to confirm your HackerNews datasource exists before ingesting.
+
+4. **Check your JSON syntax**: Use online JSON validators to verify complex JSON parameters before using them in commands.
+
+5. **Environment setup**: Ensure all required environment variables (API keys, MindsDB connection details) are properly configured.
+
+6. **Column mapping strategy**: For custom use cases, understand your source data structure and plan your content/metadata column mapping accordingly.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **JSON parsing errors**: Usually caused by incorrect quoting/escaping. Check the platform-specific examples above.
+
+2. **Table not found**: Ensure the HackerNews datasource is set up and the table name is correct (usually 'stories' or 'comments').
+
+3. **Column not found**: Verify that the columns you're referencing actually exist in the source table.
+
+4. **Agent creation failures**: Check that the model name is correct and any required API keys are configured.
+
+5. **Connection errors**: Verify MindsDB is running and accessible at the configured host/port.
+
+### Getting Help
+
+- Use `--help` with any command to see available options
+- Check the main README.md for setup and configuration details
+- Verify your environment configuration matches the examples in the documentation

--- a/README.md
+++ b/README.md
@@ -99,35 +99,88 @@ When passing complex parameters as JSON strings via options like `--metadata-map
 *   **For Linux/macOS (bash, zsh) or PowerShell:** Often, enclosing the JSON string in single quotes (`'`) is sufficient:
     Example: `--metadata-map '{"key":"value"}'`
 
-For more detailed examples and explanations for different shells, please consult the [**COMMANDS_REFERENCE.md**](./COMMANDS_REFERENCE.md) file.
+**Knowledge Base Improvements:**
+The Knowledge Base commands have been enhanced and thoroughly tested with:
+- **Auto-detection** of sensible content and metadata columns for HackerNews tables (stories, comments)
+- **Improved error handling** with clear, actionable error messages for common issues
+- **Robust JSON parsing** with platform-specific examples for Windows CMD, PowerShell, and Unix shells
+- **Automatic datasource creation** when the HackerNews datasource is missing
+- **Enhanced column mapping** flexibility for custom use cases and data sources
+- **Validated SQL generation** ensuring correct INSERT INTO ... SELECT syntax for MindsDB
+- **Windows compatibility** with proper JSON escaping examples and testing
+
+All command examples have been tested on Windows Command Prompt and include proper JSON escaping patterns.
 
 **Detailed Command Reference:**
-For detailed information on all commands, options, and examples, please consult the [**COMMANDS_REFERENCE.md**](./COMMANDS_REFERENCE.md) file.
+For detailed information on all commands, options, and comprehensive examples for different platforms, please consult the [**COMMANDS_REFERENCE.md**](./COMMANDS_REFERENCE.md) file.
 
 **Quick Examples:**
 
 *   **Setup HackerNews Datasource:**
     ```bash
-    python main.py setup hackernews --name my_hackernews_db
+    python main.py setup hackernews --name hackernews_db
     ```
-*   **Create a Knowledge Base:**
+
+*   **List Available Databases:**
     ```bash
-    python main.py kb create my_documents_kb --embedding-model nomic-embed-text
+    python main.py kb list-databases
     ```
-*   **Ingest Data into a Knowledge Base (Windows CMD/PowerShell example):**
+
+*   **Create a Knowledge Base with Custom Columns:**
     ```bash
-    python main.py kb ingest my_documents_kb --from-hackernews stories --content-column title --metadata-map "{\"doc_id\":\"id\"}" --limit 50
+    # Basic KB creation
+    python main.py kb create my_documents_kb --embedding-model nomic-embed-text --reranking-model llama3
+    
+    # KB creation with custom content and metadata columns
+    python main.py kb create hn_stories_kb --embedding-model nomic-embed-text --reranking-model llama3 --content-columns "title,text" --metadata-columns "id,by,score,time" --id-column id
     ```
-*   **Query a Knowledge Base (Windows CMD/PowerShell example with filter):**
+
+*   **Ingest Data into a Knowledge Base:**
+    
+    **Windows Command Prompt (`cmd.exe`):**
+    ```cmd
+    REM Simple ingestion with auto-detected columns (for HackerNews tables)
+    python main.py kb ingest my_documents_kb --from-hackernews stories --limit 50
+    
+    REM Custom content and metadata mapping
+    python main.py kb ingest my_documents_kb --from-hackernews stories --content-columns title --metadata-map "{\"story_id\":\"id\", \"author\":\"by\", \"score\":\"score\"}" --limit 100
+    ```
+    
+    **PowerShell/Bash/Zsh:**
     ```bash
+    # Simple ingestion with auto-detected columns (for HackerNews tables)
+    python main.py kb ingest my_documents_kb --from-hackernews stories --limit 50
+    
+    # Custom content and metadata mapping
+    python main.py kb ingest my_documents_kb --from-hackernews stories --content-columns title --metadata-map '{"story_id":"id", "author":"by", "score":"score"}' --limit 100
+    ```
+
+*   **Query a Knowledge Base:**
+    ```bash
+    # Basic query
     python main.py kb query my_documents_kb "latest trends in AI"
+    
+    # Query with metadata filter (PowerShell/Bash/Zsh)
+    python main.py kb query my_documents_kb "search specific topic" --metadata-filter '{"author":"some_user"}'
+    ```
+    
+    **Windows Command Prompt with metadata filter:**
+    ```cmd
     python main.py kb query my_documents_kb "search specific topic" --metadata-filter "{\"author\":\"some_user\"}"
     ```
-*   **Create an AI Agent for a Knowledge Base (Windows CMD/PowerShell example with params):**
+
+*   **Create an AI Agent for a Knowledge Base:**
+    
+    **PowerShell/Bash/Zsh:**
     ```bash
-    python main.py kb create-agent my_kb_agent my_documents_kb --model-name gemini-pro --agent-params "{\"temperature\":0.2, \"prompt_template\":\"Answer questions based on the KB.\"}"
-    # (Ensure GOOGLE_GEMINI_API_KEY is configured if using Google provider and api_key isn't in --agent-params)
+    python main.py kb create-agent my_kb_agent my_documents_kb --model-name gemini-pro --agent-params '{"temperature":0.2, "prompt_template":"Answer questions based on the KB."}'
     ```
+    
+    **Windows Command Prompt:**
+    ```cmd
+    python main.py kb create-agent my_kb_agent my_documents_kb --model-name gemini-pro --agent-params "{\"temperature\":0.2, \"prompt_template\":\"Answer questions based on the KB.\"}"
+    ```
+
 *   **Query the AI Agent:**
     ```bash
     python main.py kb query-agent my_kb_agent "Summarize articles about Python."

--- a/src/commands/kb_commands.py
+++ b/src/commands/kb_commands.py
@@ -142,6 +142,10 @@ def kb_ingest(ctx, kb_name, from_hackernews_table, hn_datasource, limit, content
                 "time": "time",
                 "parent": "parent"
             }
+        elif from_hackernews_table == 'hnstories':
+            parsed_metadata_map = {
+                "story_id": "id"
+            }
         click.echo(f"Using smart defaults for {from_hackernews_table}: content='{content_column}', metadata={list(parsed_metadata_map.keys())}")
 
     click.echo(f"Ingesting data from '{hn_datasource}.{from_hackernews_table}' into '{kb_name}'...")

--- a/src/commands/kb_commands.py
+++ b/src/commands/kb_commands.py
@@ -120,7 +120,7 @@ def kb_ingest(ctx, kb_name, from_hackernews_table, hn_datasource, limit, content
         try:
             parsed_metadata_map = json.loads(metadata_map)
             if not isinstance(parsed_metadata_map, dict): 
-                raise ValueError("metadata-map must be a JSON dictionary.")
+                click.echo(click.style("metadata-map must be a JSON dictionary.", fg='red')); return
             # Validate that all values are strings (column names)
             for kb_col, source_col in parsed_metadata_map.items():
                 if not isinstance(source_col, str):

--- a/src/core/mindsdb_handler.py
+++ b/src/core/mindsdb_handler.py
@@ -134,11 +134,11 @@ class MindsDBHandler:
         
         # Add content_columns, metadata_columns, and id_column if specified
         if content_columns:
-            content_columns_str = str(content_columns).replace("'", '"')  # Convert to JSON format
+            content_columns_str = json.dumps(content_columns)  # Convert to JSON format
             query += f", content_columns = {content_columns_str}"
         
         if metadata_columns:
-            metadata_columns_str = str(metadata_columns).replace("'", '"')  # Convert to JSON format
+            metadata_columns_str = json.dumps(metadata_columns)  # Convert to JSON format
             query += f", metadata_columns = {metadata_columns_str}"
         
         if id_column:

--- a/src/core/mindsdb_handler.py
+++ b/src/core/mindsdb_handler.py
@@ -196,26 +196,26 @@ class MindsDBHandler:
             print(f"Error inserting data into KB '{kb_name}' from '{source_table}': {error_msg}")
             return False
 
-    def insert_into_knowledge_base(self, kb_name: str, data: list[dict], content_column: str, metadata_columns: dict = None):
-        if not self.project: print("Error: MindsDB connection not established."); return False
-        if not data: print("No data provided for insertion."); return True
-        column_names_for_sql = [content_column];
-        if metadata_columns: column_names_for_sql.extend(metadata_columns.keys())
-        values_list_str = []
-        for record in data:
-            if content_column not in record: print(f"Warning: Record missing content_column ('{content_column}'). Skipping: {record}"); continue
-            value_tuple_parts = [f"'{str(record[content_column]).replace("'", "''")}'"]
-            if metadata_columns:
-                for kb_meta_col, data_key in metadata_columns.items():
-                    val = record.get(data_key)
-                    if val is None: value_tuple_parts.append("NULL")
-                    elif isinstance(val, (int, float, bool)): value_tuple_parts.append(str(val))
-                    else: value_tuple_parts.append(f"'{str(val).replace("'", "''")}'")
-            values_list_str.append(f"({', '.join(value_tuple_parts)})")
-        if not values_list_str: print("No valid data to insert after processing."); return False
-        query = f"INSERT INTO {self.project.name}.{kb_name} ({', '.join(column_names_for_sql)}) VALUES {', '.join(values_list_str)};"
-        try: self.execute_sql(query); print(f"Data inserted into KB '{kb_name}' successfully."); return True
-        except Exception as e: print(f"Error inserting data into KB '{kb_name}': {str(e)}"); return False
+    # def insert_into_knowledge_base(self, kb_name: str, data: list[dict], content_column: str, metadata_columns: dict = None):
+    #     if not self.project: print("Error: MindsDB connection not established."); return False
+    #     if not data: print("No data provided for insertion."); return True
+    #     column_names_for_sql = [content_column];
+    #     if metadata_columns: column_names_for_sql.extend(metadata_columns.keys())
+    #     values_list_str = []
+    #     for record in data:
+    #         if content_column not in record: print(f"Warning: Record missing content_column ('{content_column}'). Skipping: {record}"); continue
+    #         value_tuple_parts = [f"'{str(record[content_column]).replace("'", "''")}'"]
+    #         if metadata_columns:
+    #             for kb_meta_col, data_key in metadata_columns.items():
+    #                 val = record.get(data_key)
+    #                 if val is None: value_tuple_parts.append("NULL")
+    #                 elif isinstance(val, (int, float, bool)): value_tuple_parts.append(str(val))
+    #                 else: value_tuple_parts.append(f"'{str(val).replace("'", "''")}'")
+    #         values_list_str.append(f"({', '.join(value_tuple_parts)})")
+    #     if not values_list_str: print("No valid data to insert after processing."); return False
+    #     query = f"INSERT INTO {self.project.name}.{kb_name} ({', '.join(column_names_for_sql)}) VALUES {', '.join(values_list_str)};"
+    #     try: self.execute_sql(query); print(f"Data inserted into KB '{kb_name}' successfully."); return True
+    #     except Exception as e: print(f"Error inserting data into KB '{kb_name}': {str(e)}"); return False
 
     def select_from_knowledge_base(self, kb_name: str, query_text: str, metadata_filters: dict = None, limit: int = 5):
         if not self.project: print("Error: MindsDB connection not established."); return None


### PR DESCRIPTION
This pull request introduces enhancements to the Knowledge Base (KB) commands and backend logic for improved flexibility, usability, and functionality. Key changes include adding support for specifying content and metadata columns during KB creation, implementing smart defaults for HackerNews ingestion, and introducing new commands and methods for streamlined operations.

### Enhancements to Knowledge Base Commands:

* Added new options (`--content-columns`, `--metadata-columns`, `--id-column`) to the `kb_create` command for specifying content and metadata columns, with default values tailored for HackerNews. [[1]](diffhunk://#diff-c1c81336b3a178905a7ba08a8274b5432fbdabfee17bfb548d1f802655988bb1R22-R27) [[2]](diffhunk://#diff-c1c81336b3a178905a7ba08a8274b5432fbdabfee17bfb548d1f802655988bb1R44-R71)
* Enhanced the `kb_ingest` command to auto-detect `content_column` and `metadata_map` values for HackerNews tables, providing smart defaults for common use cases.

### Backend Improvements:

* Updated the `create_knowledge_base` method in `mindsdb_handler.py` to handle `content_columns`, `metadata_columns`, and `id_column` parameters, enabling more granular configuration during KB creation. [[1]](diffhunk://#diff-66ddff0ecc9291fdbb1a85e9ea39b1d8ecfd6d69396b1201aec3d25babf0ce56L114-R117) [[2]](diffhunk://#diff-66ddff0ecc9291fdbb1a85e9ea39b1d8ecfd6d69396b1201aec3d25babf0ce56R134-R146)
* Introduced a new `insert_into_knowledge_base_direct` method for direct data ingestion into KBs using MindsDB's recommended syntax, simplifying data insertion workflows.

### New Features:

* Added a `kb_list_databases` command to list all available databases/datasources in MindsDB, improving visibility and debugging capabilities.

---

![image](https://github.com/user-attachments/assets/eb963a68-eaf0-42d4-8ed8-ee30c7a37c1d)
